### PR TITLE
Fix Golangci Lint Errors

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -35,4 +35,7 @@
   exclude-use-default = false
   max-per-linter = 0
   max-same = 0
-  exclude = []
+  exclude = [
+    "`Version` is a global variable",
+    "`BuildDate` is a global variable",
+  ]

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -60,6 +60,7 @@ func Test_getLatestReleaseTagName(t *testing.T) {
 	}
 
 	for _, test := range testCases {
+		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			err := os.Setenv(envVarStructorLatestTag, test.envVarLatestTag)
 			require.NoError(t, err)

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -133,18 +133,20 @@ func buildVersions(currentVersion string, branches []string, latestTagName strin
 					Text:     versionName + " RC",
 					Selected: selected,
 				})
-			} else if sameMinor(simpleVersion, latestVersion) {
-				// latest version
-				versions = append(versions, optionVersion{
-					Text:     versionName + " Latest",
-					Selected: selected,
-				})
 			} else {
-				versions = append(versions, optionVersion{
-					Path:     versionName,
-					Text:     versionName,
-					Selected: selected,
-				})
+				if sameMinor(simpleVersion, latestVersion) {
+					// latest version
+					versions = append(versions, optionVersion{
+						Text:     versionName + " Latest",
+						Selected: selected,
+					})
+				} else {
+					versions = append(versions, optionVersion{
+						Path:     versionName,
+						Text:     versionName,
+						Selected: selected,
+					})
+				}
 			}
 		}
 	}

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -127,27 +127,28 @@ func buildVersions(currentVersion string, branches []string, latestTagName strin
 				return nil, err
 			}
 
-			if simpleVersion.GreaterThan(latestVersion) {
-				versions = append(versions, optionVersion{
+			var v optionVersion
+			switch {
+			case simpleVersion.GreaterThan(latestVersion):
+				v = optionVersion{
 					Path:     versionName,
 					Text:     versionName + " RC",
 					Selected: selected,
-				})
-			} else {
-				if sameMinor(simpleVersion, latestVersion) {
-					// latest version
-					versions = append(versions, optionVersion{
-						Text:     versionName + " Latest",
-						Selected: selected,
-					})
-				} else {
-					versions = append(versions, optionVersion{
-						Path:     versionName,
-						Text:     versionName,
-						Selected: selected,
-					})
+				}
+			case sameMinor(simpleVersion, latestVersion):
+				// latest version
+				v = optionVersion{
+					Text:     versionName + " Latest",
+					Selected: selected,
+				}
+			default:
+				v = optionVersion{
+					Path:     versionName,
+					Text:     versionName,
+					Selected: selected,
 				}
 			}
+			versions = append(versions, v)
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the errors reported by `golangci-lint` in recent version (`1.12.2`):

- The errors reported in `meta/version.go`, related to global variables, are specifically ignored: we want other global variables to be reported. These two variables cannot be switched to constants, or the `-X` passed to `go build` would not work (to report build time version and date).
- A hackity trick has been done for the `test` range error in `core/core_test.go`
- The 'ifElseChain' error in `menu/menu.go` is fixed by nesting the if / else blocks. `golangci-lint` recommends to use a `switch / case`, but it does not seem to be doable in this source.