### PR TITLE
Search for Dockerfile or switch to fallback + add a --no-cache option

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -146,7 +146,7 @@ func buildDocumentation(branches []string, branchRef string, versionsInfo types.
 		return err
 	}
 
-	baseDockerfile, useFallback, err := searchAndGetDockerFile(fallbackDockerfile.imageName, versionsInfo.CurrentPath, config.DockerfileName)
+	baseDockerfile, useFallback, err := findDockerfile(fallbackDockerfile.imageName, versionsInfo.CurrentPath, config.DockerfileName)
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func cleanAll(workDir string, debug bool) error {
 	return nil
 }
 
-func searchAndGetDockerFile(imageName string, workingDirectory string, dockerfileName string) (dockerfileInformation, bool, error) {
+func findDockerfile(imageName string, workingDirectory string, dockerfileName string) (dockerfileInformation, bool, error) {
 	var baseDockerfile dockerfileInformation
 	useFallback := true
 
@@ -393,20 +393,20 @@ func searchAndGetDockerFile(imageName string, workingDirectory string, dockerfil
 		return baseDockerfile, useFallback, errors.New("Argument dockerfileName is empty")
 	}
 
-	dockerfileSearchPaths := []string{
+	searchPaths := []string{
 		filepath.Join(workingDirectory, dockerfileName),
 		filepath.Join(workingDirectory, "docs", dockerfileName),
 	}
 
-	for _, aDockerfileSearchPath := range dockerfileSearchPaths {
-		if _, err := os.Stat(aDockerfileSearchPath); !os.IsNotExist(err) {
+	for _, searchPath := range searchPaths {
+		if _, err := os.Stat(searchPath); !os.IsNotExist(err) {
 			baseDockerfile.name = dockerfileName
-			baseDockerfile.path = aDockerfileSearchPath
+			baseDockerfile.path = searchPath
 			baseDockerfile.imageName = imageName
-			log.Printf("Found Dockerfile for building documentation in %s.", aDockerfileSearchPath)
+			log.Printf("Found Dockerfile for building documentation in %s.", searchPath)
 
 			var dockerFileContent []byte
-			dockerFileContent, err = ioutil.ReadFile(aDockerfileSearchPath)
+			dockerFileContent, err = ioutil.ReadFile(searchPath)
 			if err != nil {
 				return dockerfileInformation{}, useFallback, errors.Wrap(err, "failed to get dockerfile file content.")
 			}

--- a/core/core.go
+++ b/core/core.go
@@ -381,16 +381,16 @@ func findDockerfile(imageName string, workingDirectory string, dockerfileName st
 	var baseDockerfile dockerfileInformation
 
 	if imageName == "" {
-		return baseDockerfile, errors.New("Argument imageName is empty")
+		return baseDockerfile, errors.New("imageName is undefined")
 	}
 	if workingDirectory == "" {
-		return baseDockerfile, errors.New("Argument workingDirectory is empty")
+		return baseDockerfile, errors.New("workingDirectory is undefined")
 	}
 	if _, err := os.Stat(workingDirectory); os.IsNotExist(err) {
 		return baseDockerfile, err
 	}
 	if dockerfileName == "" {
-		return baseDockerfile, errors.New("Argument dockerfileName is empty")
+		return baseDockerfile, errors.New("dockerfileName is undefined")
 	}
 
 	searchPaths := []string{

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/containous/structor/types"
@@ -70,6 +72,169 @@ func Test_getLatestReleaseTagName(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Regexp(t, test.expected, tagName)
+		})
+	}
+}
+
+func Test_searchAndGetDockerFile(t *testing.T) {
+	workingDirPath, err := ioutil.TempDir("", "structor-test-searchAndGetDockerFile")
+	defer func() { _ = os.Remove(workingDirPath) }()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc                 string
+		imageName            string
+		workingDirectory     string
+		dockerfilePath       string
+		dockerfileContent    []byte
+		dockerfileName       string
+		expectedDockerfile   dockerfileInformation
+		expectedUseFallback  bool
+		expectedErrorMessage string
+	}{
+		{
+			desc:              "normal case with a docs.Dockerfile at the root",
+			imageName:         "mycompany/backend:1.2.1",
+			workingDirectory:  filepath.Join(workingDirPath, "normal"),
+			dockerfilePath:    filepath.Join(workingDirPath, "normal", "docs.Dockerfile"),
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "docs.Dockerfile",
+			expectedDockerfile: dockerfileInformation{
+				name:      "docs.Dockerfile",
+				imageName: "mycompany/backend:1.2.1",
+				path:      filepath.Join(workingDirPath, "normal", "docs.Dockerfile"),
+				content:   []byte("FROM alpine:3.8\n"),
+			},
+			expectedUseFallback:  false,
+			expectedErrorMessage: "",
+		},
+		{
+			desc:              "normal case with a docs.Dockerfile in the docs directory",
+			imageName:         "mycompany/backend:1.2.1",
+			workingDirectory:  filepath.Join(workingDirPath, "normal-docs"),
+			dockerfilePath:    filepath.Join(workingDirPath, "normal-docs", "docs", "docs.Dockerfile"),
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "docs.Dockerfile",
+			expectedDockerfile: dockerfileInformation{
+				name:      "docs.Dockerfile",
+				imageName: "mycompany/backend:1.2.1",
+				path:      filepath.Join(workingDirPath, "normal-docs", "docs", "docs.Dockerfile"),
+				content:   []byte("FROM alpine:3.8\n"),
+			},
+			expectedUseFallback:  false,
+			expectedErrorMessage: "",
+		},
+		{
+			desc:              "normal case with no docs.Dockerfile found",
+			imageName:         "mycompany/backend:1.2.1",
+			workingDirectory:  filepath.Join(workingDirPath, "normal-no-dockerfile-found"),
+			dockerfilePath:    "",
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "docs.Dockerfile",
+			expectedDockerfile: dockerfileInformation{
+				name:      "",
+				imageName: "",
+				path:      "",
+				content:   nil,
+			},
+			expectedUseFallback:  true,
+			expectedErrorMessage: "",
+		},
+		{
+			desc:              "error case with no imageName provided",
+			imageName:         "",
+			workingDirectory:  filepath.Join(workingDirPath, "error-no-imageName"),
+			dockerfilePath:    filepath.Join(workingDirPath, "error-no-imageName", "docs.Dockerfile"),
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "docs.Dockerfile",
+			expectedDockerfile: dockerfileInformation{
+				name:      "",
+				imageName: "",
+				path:      "",
+				content:   nil,
+			},
+			expectedUseFallback:  true,
+			expectedErrorMessage: "Argument imageName is empty",
+		},
+		{
+			desc:              "error case with no workingDirectory provided",
+			imageName:         "mycompany/backend:1.2.1",
+			workingDirectory:  "",
+			dockerfilePath:    filepath.Join(workingDirPath, "error-no-workingDirectory", "docs.Dockerfile"),
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "docs.Dockerfile",
+			expectedDockerfile: dockerfileInformation{
+				name:      "",
+				imageName: "",
+				path:      "",
+				content:   nil,
+			},
+			expectedUseFallback:  true,
+			expectedErrorMessage: "Argument workingDirectory is empty",
+		},
+		{
+			desc:              "error case with workingDirectory not found",
+			imageName:         "mycompany/backend:1.2.1",
+			workingDirectory:  "not-existing",
+			dockerfilePath:    filepath.Join(workingDirPath, "error-workingDirectory-not-found", "docs.Dockerfile"),
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "docs.Dockerfile",
+			expectedDockerfile: dockerfileInformation{
+				name:      "",
+				imageName: "",
+				path:      "",
+				content:   nil,
+			},
+			expectedUseFallback:  true,
+			expectedErrorMessage: "stat not-existing: no such file or directory",
+		},
+		{
+			desc:              "error case with no dockerfileName provided",
+			imageName:         "mycompany/backend:1.2.1",
+			workingDirectory:  filepath.Join(workingDirPath, "error-no-dockerfileName"),
+			dockerfilePath:    filepath.Join(workingDirPath, "error-no-dockerfileName", "docs.Dockerfile"),
+			dockerfileContent: []byte("FROM alpine:3.8\n"),
+			dockerfileName:    "",
+			expectedDockerfile: dockerfileInformation{
+				name:      "",
+				imageName: "",
+				path:      "",
+				content:   nil,
+			},
+			expectedUseFallback:  true,
+			expectedErrorMessage: "Argument dockerfileName is empty",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run("group", func(t *testing.T) {
+			t.Run(test.desc, func(t *testing.T) {
+				t.Parallel()
+
+				if test.workingDirectory != "" && filepath.IsAbs(test.workingDirectory) {
+					err = os.MkdirAll(test.workingDirectory, os.ModePerm)
+					require.NoError(t, err)
+				}
+
+				if test.dockerfilePath != "" {
+					err = os.MkdirAll(filepath.Dir(test.dockerfilePath), os.ModePerm)
+					require.NoError(t, err)
+					if test.dockerfileContent != nil {
+						err = ioutil.WriteFile(test.dockerfilePath, test.dockerfileContent, os.ModePerm)
+						require.NoError(t, err)
+					}
+				}
+				resultingDockerfile, resultingUseFallback, resultingError := searchAndGetDockerFile(test.imageName, test.workingDirectory, test.dockerfileName)
+
+				assert.Equal(t, test.expectedUseFallback, resultingUseFallback)
+				if test.expectedErrorMessage != "" {
+					assert.EqualError(t, resultingError, test.expectedErrorMessage)
+				} else {
+					assert.Equal(t, nil, resultingError)
+				}
+				assert.Equal(t, test.expectedDockerfile, resultingDockerfile)
+			})
 		})
 	}
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -157,6 +157,7 @@ func Test_findDockerFile(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
+
 			if test.workingDirectory != "" && filepath.IsAbs(test.workingDirectory) {
 				err = os.MkdirAll(test.workingDirectory, os.ModePerm)
 				require.NoError(t, err)
@@ -170,13 +171,14 @@ func Test_findDockerFile(t *testing.T) {
 					require.NoError(t, err)
 				}
 			}
+
 			resultingDockerfile, resultingError := getDockerfile(fallbackDockerfile, test.workingDirectory, test.dockerfileName)
 
 			if test.expectedErrorMessage != "" {
 				assert.EqualError(t, resultingError, test.expectedErrorMessage)
 			} else {
 				require.NoError(t, resultingError)
-				assert.Equal(t, *test.expectedDockerfile, *resultingDockerfile)
+				assert.Equal(t, test.expectedDockerfile, resultingDockerfile)
 			}
 		})
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -139,7 +139,7 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 			dockerfileContent:    "FROM alpine:3.8\n",
 			dockerfileName:       "docs.Dockerfile",
 			expectedDockerfile:   dockerfileInformation{},
-			expectedErrorMessage: "Argument imageName is empty",
+			expectedErrorMessage: "imageName is undefined",
 		},
 		{
 			desc:                 "error case with no workingDirectory provided",
@@ -149,7 +149,7 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 			dockerfileContent:    "FROM alpine:3.8\n",
 			dockerfileName:       "docs.Dockerfile",
 			expectedDockerfile:   dockerfileInformation{},
-			expectedErrorMessage: "Argument workingDirectory is empty",
+			expectedErrorMessage: "workingDirectory is undefined",
 		},
 		{
 			desc:                 "error case with workingDirectory not found",
@@ -160,16 +160,6 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 			dockerfileName:       "docs.Dockerfile",
 			expectedDockerfile:   dockerfileInformation{},
 			expectedErrorMessage: "stat not-existing: no such file or directory",
-		},
-		{
-			desc:                 "error case with no dockerfileName provided",
-			imageName:            "mycompany/backend:1.2.1",
-			workingDirectory:     filepath.Join(workingDirPath, "error-no-dockerfileName"),
-			dockerfilePath:       filepath.Join(workingDirPath, "error-no-dockerfileName", "docs.Dockerfile"),
-			dockerfileContent:    "FROM alpine:3.8\n",
-			dockerfileName:       "",
-			expectedDockerfile:   dockerfileInformation{},
-			expectedErrorMessage: "Argument dockerfileName is empty",
 		},
 	}
 

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -89,7 +89,6 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 		dockerfileContent    string
 		dockerfileName       string
 		expectedDockerfile   dockerfileInformation
-		expectedUseFallback  bool
 		expectedErrorMessage string
 	}{
 		{
@@ -105,7 +104,6 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 				path:      filepath.Join(workingDirPath, "normal", "docs.Dockerfile"),
 				content:   []byte("FROM alpine:3.8\n"),
 			},
-			expectedUseFallback:  false,
 			expectedErrorMessage: "",
 		},
 		{
@@ -121,87 +119,56 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 				path:      filepath.Join(workingDirPath, "normal-docs", "docs", "docs.Dockerfile"),
 				content:   []byte("FROM alpine:3.8\n"),
 			},
-			expectedUseFallback:  false,
 			expectedErrorMessage: "",
 		},
 		{
-			desc:              "normal case with no docs.Dockerfile found",
-			imageName:         "mycompany/backend:1.2.1",
-			workingDirectory:  filepath.Join(workingDirPath, "normal-no-dockerfile-found"),
-			dockerfilePath:    "",
-			dockerfileContent: "FROM alpine:3.8\n",
-			dockerfileName:    "docs.Dockerfile",
-			expectedDockerfile: dockerfileInformation{
-				name:      "",
-				imageName: "",
-				path:      "",
-				content:   nil,
-			},
-			expectedUseFallback:  true,
+			desc:                 "normal case with no docs.Dockerfile found",
+			imageName:            "mycompany/backend:1.2.1",
+			workingDirectory:     filepath.Join(workingDirPath, "normal-no-dockerfile-found"),
+			dockerfilePath:       "",
+			dockerfileContent:    "FROM alpine:3.8\n",
+			dockerfileName:       "docs.Dockerfile",
+			expectedDockerfile:   dockerfileInformation{},
 			expectedErrorMessage: "",
 		},
 		{
-			desc:              "error case with no imageName provided",
-			imageName:         "",
-			workingDirectory:  filepath.Join(workingDirPath, "error-no-imageName"),
-			dockerfilePath:    filepath.Join(workingDirPath, "error-no-imageName", "docs.Dockerfile"),
-			dockerfileContent: "FROM alpine:3.8\n",
-			dockerfileName:    "docs.Dockerfile",
-			expectedDockerfile: dockerfileInformation{
-				name:      "",
-				imageName: "",
-				path:      "",
-				content:   nil,
-			},
-			expectedUseFallback:  true,
+			desc:                 "error case with no imageName provided",
+			imageName:            "",
+			workingDirectory:     filepath.Join(workingDirPath, "error-no-imageName"),
+			dockerfilePath:       filepath.Join(workingDirPath, "error-no-imageName", "docs.Dockerfile"),
+			dockerfileContent:    "FROM alpine:3.8\n",
+			dockerfileName:       "docs.Dockerfile",
+			expectedDockerfile:   dockerfileInformation{},
 			expectedErrorMessage: "Argument imageName is empty",
 		},
 		{
-			desc:              "error case with no workingDirectory provided",
-			imageName:         "mycompany/backend:1.2.1",
-			workingDirectory:  "",
-			dockerfilePath:    filepath.Join(workingDirPath, "error-no-workingDirectory", "docs.Dockerfile"),
-			dockerfileContent: "FROM alpine:3.8\n",
-			dockerfileName:    "docs.Dockerfile",
-			expectedDockerfile: dockerfileInformation{
-				name:      "",
-				imageName: "",
-				path:      "",
-				content:   nil,
-			},
-			expectedUseFallback:  true,
+			desc:                 "error case with no workingDirectory provided",
+			imageName:            "mycompany/backend:1.2.1",
+			workingDirectory:     "",
+			dockerfilePath:       filepath.Join(workingDirPath, "error-no-workingDirectory", "docs.Dockerfile"),
+			dockerfileContent:    "FROM alpine:3.8\n",
+			dockerfileName:       "docs.Dockerfile",
+			expectedDockerfile:   dockerfileInformation{},
 			expectedErrorMessage: "Argument workingDirectory is empty",
 		},
 		{
-			desc:              "error case with workingDirectory not found",
-			imageName:         "mycompany/backend:1.2.1",
-			workingDirectory:  "not-existing",
-			dockerfilePath:    filepath.Join(workingDirPath, "error-workingDirectory-not-found", "docs.Dockerfile"),
-			dockerfileContent: "FROM alpine:3.8\n",
-			dockerfileName:    "docs.Dockerfile",
-			expectedDockerfile: dockerfileInformation{
-				name:      "",
-				imageName: "",
-				path:      "",
-				content:   nil,
-			},
-			expectedUseFallback:  true,
+			desc:                 "error case with workingDirectory not found",
+			imageName:            "mycompany/backend:1.2.1",
+			workingDirectory:     "not-existing",
+			dockerfilePath:       filepath.Join(workingDirPath, "error-workingDirectory-not-found", "docs.Dockerfile"),
+			dockerfileContent:    "FROM alpine:3.8\n",
+			dockerfileName:       "docs.Dockerfile",
+			expectedDockerfile:   dockerfileInformation{},
 			expectedErrorMessage: "stat not-existing: no such file or directory",
 		},
 		{
-			desc:              "error case with no dockerfileName provided",
-			imageName:         "mycompany/backend:1.2.1",
-			workingDirectory:  filepath.Join(workingDirPath, "error-no-dockerfileName"),
-			dockerfilePath:    filepath.Join(workingDirPath, "error-no-dockerfileName", "docs.Dockerfile"),
-			dockerfileContent: "FROM alpine:3.8\n",
-			dockerfileName:    "",
-			expectedDockerfile: dockerfileInformation{
-				name:      "",
-				imageName: "",
-				path:      "",
-				content:   nil,
-			},
-			expectedUseFallback:  true,
+			desc:                 "error case with no dockerfileName provided",
+			imageName:            "mycompany/backend:1.2.1",
+			workingDirectory:     filepath.Join(workingDirPath, "error-no-dockerfileName"),
+			dockerfilePath:       filepath.Join(workingDirPath, "error-no-dockerfileName", "docs.Dockerfile"),
+			dockerfileContent:    "FROM alpine:3.8\n",
+			dockerfileName:       "",
+			expectedDockerfile:   dockerfileInformation{},
 			expectedErrorMessage: "Argument dockerfileName is empty",
 		},
 	}
@@ -223,9 +190,8 @@ func Test_searchAndGetDockerFile(t *testing.T) {
 					require.NoError(t, err)
 				}
 			}
-			resultingDockerfile, resultingUseFallback, resultingError := searchAndGetDockerFile(test.imageName, test.workingDirectory, test.dockerfileName)
+			resultingDockerfile, resultingError := findDockerfile(test.imageName, test.workingDirectory, test.dockerfileName)
 
-			assert.Equal(t, test.expectedUseFallback, resultingUseFallback)
 			if test.expectedErrorMessage != "" {
 				assert.EqualError(t, resultingError, test.expectedErrorMessage)
 			} else {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -175,13 +175,8 @@ func Test_findDockerFile(t *testing.T) {
 			if test.expectedErrorMessage != "" {
 				assert.EqualError(t, resultingError, test.expectedErrorMessage)
 			} else {
-				assert.NoError(t, resultingError)
-			}
-			if test.expectedDockerfile != nil {
-				require.NotNil(t, resultingDockerfile)
+				require.NoError(t, resultingError)
 				assert.Equal(t, *test.expectedDockerfile, *resultingDockerfile)
-			} else {
-				assert.Nil(t, resultingDockerfile)
 			}
 		})
 	}

--- a/requirements-override.txt
+++ b/requirements-override.txt
@@ -1,1 +1,6 @@
 tornado<5
+mkdocs==0.16.3
+pymdown-extensions==4.12
+mkdocs-bootswatch==0.4.0
+mkdocs-material==1.12.2
+markdown==2.6.11

--- a/requirements-override.txt
+++ b/requirements-override.txt
@@ -1,6 +1,0 @@
-tornado<5
-mkdocs==0.16.3
-pymdown-extensions==4.12
-mkdocs-bootswatch==0.4.0
-mkdocs-material==1.12.2
-markdown==2.6.11

--- a/structor.go
+++ b/structor.go
@@ -15,12 +15,14 @@ import (
 const (
 	defaultDockerImageName = "doc-site"
 	defaultDockerfileName  = "docs.Dockerfile"
+	defaultNoCache         = false
 )
 
 func main() {
 	config := &types.Configuration{
 		DockerImageName: defaultDockerImageName,
 		DockerfileName:  defaultDockerfileName,
+		NoCache:         defaultNoCache,
 	}
 
 	defaultPointersConfig := &types.Configuration{

--- a/structor.go
+++ b/structor.go
@@ -14,11 +14,13 @@ import (
 
 const (
 	defaultDockerImageName = "doc-site"
+	defaultDockerfileName  = "docs.Dockerfile"
 )
 
 func main() {
 	config := &types.Configuration{
 		DockerImageName: defaultDockerImageName,
+		DockerfileName:  defaultDockerfileName,
 	}
 
 	defaultPointersConfig := &types.Configuration{

--- a/types/types.go
+++ b/types/types.go
@@ -5,12 +5,12 @@ type Configuration struct {
 	Owner                  string     `short:"o" description:"Repository owner. [required]"`
 	RepositoryName         string     `short:"r" long:"repo-name" description:"Repository name. [required]"`
 	Debug                  bool       `long:"debug" description:"Debug mode."`
-	DockerfileURL          string     `short:"d" long:"dockerfile-url" description:"Dockerfile URL. [required]"`
+	DockerfileURL          string     `short:"d" long:"dockerfile-url" description:"Use this Dockerfile when --dockerfile-name is not found. Can be a file path. [required]"`
 	DockerfileName         string     `long:"dockerfile-name" description:"Search and use this Dockerfile in the repository (in './docs/' or in './') for building documentation."`
 	ExperimentalBranchName string     `long:"exp-branch" description:"Build a branch as experimental."`
 	DockerImageName        string     `long:"image-name" description:"Docker image name."`
 	Menu                   *MenuFiles `long:"menu" description:"Menu templates files."`
-	RequirementsURL        string     `long:"rqts-url" description:"URL of the requirements.txt file."`
+	RequirementsURL        string     `long:"rqts-url" description:"Use this requirements.txt when --dockerfile-name is not found. Can be a file path."`
 }
 
 // MenuFiles menu template files references

--- a/types/types.go
+++ b/types/types.go
@@ -6,6 +6,7 @@ type Configuration struct {
 	RepositoryName         string     `short:"r" long:"repo-name" description:"Repository name. [required]"`
 	Debug                  bool       `long:"debug" description:"Debug mode."`
 	DockerfileURL          string     `short:"d" long:"dockerfile-url" description:"Dockerfile URL. [required]"`
+	DockerfileName         string     `long:"dockerfile-name" description:"Search and use this Dockerfile in the repository (in './docs/' or in './') for building documentation."`
 	ExperimentalBranchName string     `long:"exp-branch" description:"Build a branch as experimental."`
 	DockerImageName        string     `long:"image-name" description:"Docker image name."`
 	Menu                   *MenuFiles `long:"menu" description:"Menu templates files."`

--- a/types/types.go
+++ b/types/types.go
@@ -11,6 +11,7 @@ type Configuration struct {
 	DockerImageName        string     `long:"image-name" description:"Docker image name."`
 	Menu                   *MenuFiles `long:"menu" description:"Menu templates files."`
 	RequirementsURL        string     `long:"rqts-url" description:"Use this requirements.txt when --dockerfile-name is not found. Can be a file path."`
+	NoCache                bool       `long:"no-cache" description:"Set to 'true' to disable the Docker build cache."`
 }
 
 // MenuFiles menu template files references


### PR DESCRIPTION
### Why this PR

If you build Traefik's documentation from a fresh Docker Engine (with no cached layers),  then it fails because of some mkdocs/tornado pip dependencies issues.
Traefik's CI is currently reusing its cache, leading in a false positive build.

The goals of this PR are:

* to fix this issue
* to allows structor to support restructuring Traefik's documentation ( as the tentative in https://github.com/containous/traefik/pull/3997)
* to prepare future upgrades of mkdocs to 1.x version for any documentation built with structor

### What does this PR change

* Adds 2 new flags for structor:
  - `--no-cache` to allows building without cache for better debugging
  - `--dockerfile-name` to specify the Dockerfile's name to search for, before using the `--dockerfile-url` as fallback (with the requirements)
* Add a new behavior where structor searches for Dockerfile in the repository root, or in a folder named `docs`. If it cannot find it, then it switch to a fallback dockerfile, provided with `--dockerfile-url`. Tests are included to cover different scenarios.
* Update the override-requirements used as fallback, so it has a fixed version of mkdocs and dependencies, which work for all Traefik's documentation branches without any `Dockerfile` in it


