### PR TITLE
Adds ability to search for documentation in repository root and in "./docs/"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,73 +2,103 @@
 
 
 [[projects]]
+  digest = "1:427545cfc59b86e0ebd433a2de0fb77522221681b178285df66bebba796d9a93"
   name = "github.com/containous/flaeg"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
+  pruneopts = ""
   revision = "b4c2f060875361c070ed2bc300c5929b82f5fa2e"
   version = "v1.1.2"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:94158926759c3333201f81eee5a21112f7ae9d000b4d6926455008c7ab3fb7fc"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
+  pruneopts = ""
   revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
 
 [[projects]]
+  digest = "1:b0009f58f7d00653db48b2fc0e67f2de7bc63b68459bd1fa0fc6e2e923ae1dd7"
   name = "github.com/ldez/go-git-cmd-wrapper"
   packages = [
     "branch",
     "git",
     "types",
-    "worktree"
+    "worktree",
   ]
+  pruneopts = ""
   revision = "4789812722d1cd40bdaafaa82c5b6644c47b9c81"
   version = "v0.22.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c5321c18190f47a3cee2e4c357dde460cd66b22b324b97a17fc5145d934f9d56"
   name = "github.com/ogier/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "45c278ab3607870051a2ea9040bb85fcb8557481"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3c9c0bd0a72d8c92c2f306162937853a395d8a1194af026b690663164e6c878a"
+  input-imports = [
+    "github.com/containous/flaeg",
+    "github.com/hashicorp/go-version",
+    "github.com/ldez/go-git-cmd-wrapper/branch",
+    "github.com/ldez/go-git-cmd-wrapper/git",
+    "github.com/ldez/go-git-cmd-wrapper/types",
+    "github.com/ldez/go-git-cmd-wrapper/worktree",
+    "github.com/ogier/pflag",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/core/core.go
+++ b/core/core.go
@@ -171,10 +171,10 @@ func getDocumentationRoot(repositoryRoot string) (string, error) {
 
 		if _, err := os.Stat(filepath.Join(candidateDocsRootPath, manifest.FileName)); !os.IsNotExist(err) {
 			log.Printf("Found %s for building documentation in %s.", manifest.FileName, candidateDocsRootPath)
-
 			return candidateDocsRootPath, nil
 		}
 	}
+
 	return "", fmt.Errorf("no file %s found in %s (search path was: %s)", manifest.FileName, repositoryRoot, strings.Join(docsRootSearchPaths, ","))
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containous/structor/copy"
 	"github.com/containous/structor/gh"
+	"github.com/containous/structor/manifest"
 	"github.com/containous/structor/menu"
 	"github.com/containous/structor/repository"
 	"github.com/containous/structor/types"
@@ -177,13 +178,8 @@ func getDocumentationRoot(repositoryRoot string) (string, error) {
 	for _, docsRootSearchPath := range docsRootSearchPaths {
 		candidateDocsRootPath := filepath.Join(repositoryRoot, docsRootSearchPath)
 
-		if _, err := os.Stat(filepath.Join(candidateDocsRootPath, menu.ManifestFileName)); !os.IsNotExist(err) {
-			log.Printf("Found %s for building documentation in %s.", menu.ManifestFileName, candidateDocsRootPath)
-
-			// Sanity checking: the file "requirements.txt" must be in the candidate directory, next to manifest file
-			if _, err := os.Stat(filepath.Join(candidateDocsRootPath, "requirements.txt")); os.IsNotExist(err) {
-				return "", err
-			}
+		if _, err := os.Stat(filepath.Join(candidateDocsRootPath, manifest.FileName)); !os.IsNotExist(err) {
+			log.Printf("Found %s for building documentation in %s.", manifest.FileName, candidateDocsRootPath)
 
 			return candidateDocsRootPath, nil
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -127,21 +127,37 @@ func process(workDir string, repoID types.RepoID, fallbackDockerfile dockerfileI
 			return err
 		}
 
-		outputDir := siteDir
-		if strings.HasPrefix(latestTagName, versionName) {
-			err = copy.Copy(filepath.Join(versionsInfo.CurrentPath, "site"), outputDir)
-			if err != nil {
-				return err
-			}
+		err = copyVersionSiteToOutputSite(versionsInfo, siteDir)
+		if err != nil {
+			return err
 		}
 
-		outputDir = filepath.Join(outputDir, versionName)
-		err = copy.Copy(filepath.Join(versionsInfo.CurrentPath, "site"), outputDir)
+	}
+
+	return nil
+}
+
+// copyVersionSiteToOutputSite adds the generated documentation for the version described in ${versionsInfo} to the output directory.
+// If the current version (branch) name is related to the latest tag, then it's copied at the root of the output directory.
+// Else it is copied under a directory named after the version, at the root of the output directory.
+func copyVersionSiteToOutputSite(versionsInfo types.VersionsInformation, siteDir string) error {
+	outputDir := siteDir
+	if strings.HasPrefix(versionsInfo.Latest, versionsInfo.Current) {
+		currentSiteDir, err := getDocumentationRoot(versionsInfo.CurrentPath)
+		if err != nil {
+			return err
+		}
+		err = copy.Copy(filepath.Join(currentSiteDir, "site"), outputDir)
 		if err != nil {
 			return err
 		}
 	}
 
+	outputDir = filepath.Join(outputDir, versionsInfo.Current)
+	err := copy.Copy(filepath.Join(versionsInfo.CurrentPath, "site"), outputDir)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -115,6 +115,11 @@ func process(workDir string, repoID types.RepoID, fallbackDockerfile dockerfileI
 			return err
 		}
 
+		err = checkRequirements(versionDocsRoot)
+		if err != nil {
+			return err
+		}
+
 		versionsInfo := types.VersionsInformation{
 			Current:      versionName,
 			Latest:       latestTagName,
@@ -185,7 +190,12 @@ func getDocumentationRoot(repositoryRoot string) (string, error) {
 		}
 	}
 
-	return "", errors.New("no file " + menu.ManifestFileName + " found in " + repositoryRoot + " (search path was: " + strings.Join(docsRootSearchPaths[:], ",") + ")")
+// checkRequirements return an error if the requirements file is not found in the doc root directory.
+func checkRequirements(docRoot string) error {
+	if _, err := os.Stat(filepath.Join(docRoot, "requirements.txt")); os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func buildDocumentation(branches []string, versionsInfo types.VersionsInformation,

--- a/core/core.go
+++ b/core/core.go
@@ -180,10 +180,8 @@ func getDocumentationRoot(repositoryRoot string) (string, error) {
 
 // checkRequirements return an error if the requirements file is not found in the doc root directory.
 func checkRequirements(docRoot string) error {
-	if _, err := os.Stat(filepath.Join(docRoot, "requirements.txt")); os.IsNotExist(err) {
-		return err
-	}
-	return nil
+	_, err := os.Stat(filepath.Join(docRoot, "requirements.txt"))
+	return err
 }
 
 func buildDocumentation(branches []string, versionsInfo types.VersionsInformation,

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,0 +1,4 @@
+package manifest
+
+// FileName file name of the mkdocs manifest file
+const FileName = "mkdocs.yml"

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,4 +1,37 @@
 package manifest
 
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
 // FileName file name of the mkdocs manifest file
 const FileName = "mkdocs.yml"
+
+// GetManifestDocsDir returns the path to the directory pointed by "docs_dir" in the manifest file.
+// If docs_dir is not set, then the directory containing the manifest is returned.
+func GetManifestDocsDir(manifestFilePath string) (string, error) {
+	bytes, err := ioutil.ReadFile(manifestFilePath)
+	if err != nil {
+		return "", errors.Wrap(err, "error when reading MkDocs Manifest.")
+	}
+
+	manif := make(map[string]interface{})
+
+	err = yaml.Unmarshal(bytes, manif)
+	if err != nil {
+		return "", errors.Wrap(err, "error when during unmarshal of the MkDocs Manifest.")
+	}
+
+	manifestDir := filepath.Dir(manifestFilePath)
+
+	if value, ok := manif["docs_dir"]; ok {
+
+		return filepath.Join(manifestDir, value.(string)), nil
+	}
+
+	return manifestDir, nil
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -2,36 +2,74 @@ package manifest
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
 
-// FileName file name of the mkdocs manifest file
+// FileName file name of the mkdocs manifest file.
 const FileName = "mkdocs.yml"
 
-// GetManifestDocsDir returns the path to the directory pointed by "docs_dir" in the manifest file.
-// If docs_dir is not set, then the directory containing the manifest is returned.
-func GetManifestDocsDir(manifestFilePath string) (string, error) {
+// Read Reads the manifest.
+func Read(manifestFilePath string) (map[string]interface{}, error) {
 	bytes, err := ioutil.ReadFile(manifestFilePath)
 	if err != nil {
-		return "", errors.Wrap(err, "error when reading MkDocs Manifest.")
+		return nil, errors.Wrap(err, "error when reading MkDocs Manifest.")
 	}
 
 	manif := make(map[string]interface{})
 
 	err = yaml.Unmarshal(bytes, manif)
 	if err != nil {
-		return "", errors.Wrap(err, "error when during unmarshal of the MkDocs Manifest.")
+		return nil, errors.Wrap(err, "error when during unmarshal of the MkDocs Manifest.")
 	}
 
+	return manif, nil
+}
+
+// Save Saves the manifest.
+func Save(manifestFilePath string, manif map[string]interface{}) error {
+	out, err := yaml.Marshal(manif)
+	if err != nil {
+		return errors.Wrap(err, "error when marshal MkDocs Manifest.")
+	}
+
+	return ioutil.WriteFile(manifestFilePath, out, os.ModePerm)
+}
+
+// GetDocsDir returns the path to the directory pointed by "docs_dir" in the manifest file.
+// If docs_dir is not set, then the directory containing the manifest is returned.
+func GetDocsDir(manifestFilePath string, manif map[string]interface{}) (string, error) {
 	manifestDir := filepath.Dir(manifestFilePath)
 
 	if value, ok := manif["docs_dir"]; ok {
-
 		return filepath.Join(manifestDir, value.(string)), nil
 	}
-
 	return manifestDir, nil
+}
+
+// AppendExtraJs Appends a file path to the "extra_javascript" in the manifest file.
+func AppendExtraJs(jsFile string, manif map[string]interface{}) {
+	if len(jsFile) > 0 {
+		var extraJs []interface{}
+		if val, ok := manif["extra_javascript"]; ok {
+			extraJs = val.([]interface{})
+		}
+		extraJs = append(extraJs, jsFile)
+		manif["extra_javascript"] = extraJs
+	}
+}
+
+// AppendExtraCSS Appends a file path to the "extra_css" in the manifest file.
+func AppendExtraCSS(cssFile string, manif map[string]interface{}) {
+	if len(cssFile) > 0 {
+		var extraCSS []interface{}
+		if val, ok := manif["extra_css"]; ok {
+			extraCSS = val.([]interface{})
+		}
+		extraCSS = append(extraCSS, cssFile)
+		manif["extra_css"] = extraCSS
+	}
 }

--- a/menu/manifest.go
+++ b/menu/manifest.go
@@ -8,9 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// ManifestFileName file name of the mkdocs manifest file
-const ManifestFileName = "mkdocs.yml"
-
 func editManifest(mkdocsFilePath string, versionJsFile string, versionCSSFile string) error {
 	bytes, err := ioutil.ReadFile(mkdocsFilePath)
 	if err != nil {

--- a/menu/manifest.go
+++ b/menu/manifest.go
@@ -8,6 +8,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ManifestFileName file name of the mkdocs manifest file
+const ManifestFileName = "mkdocs.yml"
+
 func editManifest(mkdocsFilePath string, versionJsFile string, versionCSSFile string) error {
 	bytes, err := ioutil.ReadFile(mkdocsFilePath)
 	if err != nil {

--- a/menu/manifest.go
+++ b/menu/manifest.go
@@ -18,7 +18,7 @@ func editManifest(mkdocsFilePath string, versionJsFile string, versionCSSFile st
 
 	err = yaml.Unmarshal(bytes, manif)
 	if err != nil {
-		return errors.Wrap(err, "error when unmarshal MkDocs Manifest.")
+		return errors.Wrap(err, "error when during unmarshal of the MkDocs Manifest.")
 	}
 
 	// Append menu JS file

--- a/menu/manifest.go
+++ b/menu/manifest.go
@@ -1,53 +1,16 @@
 package menu
 
 import (
-	"io/ioutil"
-	"os"
-
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"github.com/containous/structor/manifest"
 )
 
-func editManifest(mkdocsFilePath string, versionJsFile string, versionCSSFile string) error {
-	bytes, err := ioutil.ReadFile(mkdocsFilePath)
-	if err != nil {
-		return errors.Wrap(err, "error when reading MkDocs Manifest.")
-	}
-
-	manif := make(map[string]interface{})
-
-	err = yaml.Unmarshal(bytes, manif)
-	if err != nil {
-		return errors.Wrap(err, "error when during unmarshal of the MkDocs Manifest.")
-	}
-
+func editManifest(manif map[string]interface{}, versionJsFile string, versionCSSFile string) {
 	// Append menu JS file
-	if len(versionJsFile) > 0 {
-		var extraJs []interface{}
-		if val, ok := manif["extra_javascript"]; ok {
-			extraJs = val.([]interface{})
-		}
-		extraJs = append(extraJs, versionJsFile)
-		manif["extra_javascript"] = extraJs
-	}
+	manifest.AppendExtraJs(versionJsFile, manif)
 
 	// Append menu CSS file
-	if len(versionCSSFile) > 0 {
-		var extraCSS []interface{}
-		if val, ok := manif["extra_css"]; ok {
-			extraCSS = val.([]interface{})
-		}
-		extraCSS = append(extraCSS, versionCSSFile)
-		manif["extra_css"] = extraCSS
-	}
+	manifest.AppendExtraCSS(versionCSSFile, manif)
 
 	// reset site URL
 	manif["site_url"] = ""
-
-	out, err := yaml.Marshal(manif)
-	if err != nil {
-		return errors.Wrap(err, "error when marshal MkDocs Manifest.")
-	}
-
-	return ioutil.WriteFile(mkdocsFilePath, out, os.ModePerm)
 }

--- a/menu/manifest_test.go
+++ b/menu/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containous/structor/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,7 +65,12 @@ func Test_editManifest(t *testing.T) {
 			testManifest, err := setupTestManifest(test.source)
 			require.NoError(t, err)
 
-			err = editManifest(testManifest, test.versionJsFile, test.versionCSSFile)
+			manif, err := manifest.Read(testManifest)
+			require.NoError(t, err)
+
+			editManifest(manif, test.versionJsFile, test.versionCSSFile)
+
+			err = manifest.Save(testManifest, manif)
 			require.NoError(t, err)
 
 			assertSameContent(t, test.expected, testManifest)

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/containous/structor/manifest"
 	"github.com/containous/structor/types"
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
@@ -25,7 +26,7 @@ const menuCSSFileName = "structor-menu.css"
 
 // Build the menu
 func Build(versionsInfo types.VersionsInformation, branches []string, menuContent types.MenuContent) error {
-	manifestFile := filepath.Join(versionsInfo.CurrentPath, ManifestFileName)
+	manifestFile := filepath.Join(versionsInfo.CurrentPath, manifest.FileName)
 
 	var manifestJsFilePath string
 	if len(menuContent.Js) > 0 {

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -2,6 +2,7 @@ package menu
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,12 +28,18 @@ const menuCSSFileName = "structor-menu.css"
 // Build the menu
 func Build(versionsInfo types.VersionsInformation, branches []string, menuContent types.MenuContent) error {
 	manifestFile := filepath.Join(versionsInfo.CurrentPath, manifest.FileName)
+	manifestDocsDir, err := manifest.GetManifestDocsDir(manifestFile)
+	if err != nil {
+		return err
+	}
+	log.Printf("Using docs_dir from manifest: %s", manifestDocsDir)
 
 	var manifestJsFilePath string
 	if len(menuContent.Js) > 0 {
+
 		manifestJsFilePath = filepath.Join("theme", "js", menuJsFileName)
 
-		jsDir := filepath.Join(versionsInfo.CurrentPath, "docs", "theme", "js")
+		jsDir := filepath.Join(manifestDocsDir, "theme", "js")
 		_, errStat := os.Stat(jsDir)
 		if os.IsNotExist(errStat) {
 			errDir := os.MkdirAll(jsDir, os.ModePerm)
@@ -52,7 +59,7 @@ func Build(versionsInfo types.VersionsInformation, branches []string, menuConten
 	if len(menuContent.CSS) > 0 {
 		manifestCSSFilePath = filepath.Join("theme", "css", menuCSSFileName)
 
-		cssDir := filepath.Join(versionsInfo.CurrentPath, "docs", "theme", "css")
+		cssDir := filepath.Join(manifestDocsDir, "theme", "css")
 		_, errStat := os.Stat(cssDir)
 		if os.IsNotExist(errStat) {
 			errDir := os.MkdirAll(cssDir, os.ModePerm)
@@ -67,7 +74,7 @@ func Build(versionsInfo types.VersionsInformation, branches []string, menuConten
 		}
 	}
 
-	err := editManifest(manifestFile, manifestJsFilePath, manifestCSSFilePath)
+	err = editManifest(manifestFile, manifestJsFilePath, manifestCSSFilePath)
 	if err != nil {
 		return errors.Wrap(err, "error when edit MkDocs manifest")
 	}

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -25,7 +25,7 @@ const menuCSSFileName = "structor-menu.css"
 
 // Build the menu
 func Build(versionsInfo types.VersionsInformation, branches []string, menuContent types.MenuContent) error {
-	manifestFile := filepath.Join(versionsInfo.CurrentPath, "mkdocs.yml")
+	manifestFile := filepath.Join(versionsInfo.CurrentPath, ManifestFileName)
 
 	var manifestJsFilePath string
 	if len(menuContent.Js) > 0 {


### PR DESCRIPTION
This PR introduce the ability to search, build and manage documentation when it's located in the `./docs` sub directory.

Please note that it fixes an issue coming from #2 (and currently on master): if `docs.Dockerfile` is found into `./docs`, then the build fails if `requirements.txt` is not next to it. But if we let `mkdocs.yml` at the root of the repo (on the same version), it also requires `requirements.txt` next to it.