### PR TITLE
Load .env file during documentation build with a docker image

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -226,10 +226,11 @@ func buildDocumentation(branches []string, versionsInfo types.VersionsInformatio
 		return err
 	}
 
-	args := []string{"run", "--rm", "-v", versionsInfo.CurrentPath + ":/mkdocs", dockerImageFullName, "mkdocs", "build"}
+	args := []string{"run", "--rm", "-v", versionsInfo.CurrentPath + ":/mkdocs"}
 	if _, err = os.Stat(filepath.Join(versionsInfo.CurrentPath, ".env")); err == nil {
-		args = []string{"run", "--rm", fmt.Sprintf("--env-file=%s", filepath.Join(versionsInfo.CurrentPath, ".env")), "-v", versionsInfo.CurrentPath + ":/mkdocs", dockerImageFullName, "mkdocs", "build"}
+		args = append(args, fmt.Sprintf("--env-file=%s", filepath.Join(versionsInfo.CurrentPath, ".env")))
 	}
+	args = append(args, dockerImageFullName, "mkdocs", "build")
 
 	// Run image
 	output, err := docker.Exec(config.Debug, args...)

--- a/core/core.go
+++ b/core/core.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -225,8 +226,13 @@ func buildDocumentation(branches []string, versionsInfo types.VersionsInformatio
 		return err
 	}
 
+	args := []string{"run", "--rm", "-v", versionsInfo.CurrentPath + ":/mkdocs", dockerImageFullName, "mkdocs", "build"}
+	if _, err = os.Stat(filepath.Join(versionsInfo.CurrentPath, ".env")); err == nil {
+		args = []string{"run", "--rm", fmt.Sprintf("--env-file=%s", filepath.Join(versionsInfo.CurrentPath, ".env")), "-v", versionsInfo.CurrentPath + ":/mkdocs", dockerImageFullName, "mkdocs", "build"}
+	}
+
 	// Run image
-	output, err := docker.Exec(config.Debug, "run", "--rm", "-v", versionsInfo.CurrentPath+":/mkdocs", dockerImageFullName, "mkdocs", "build")
+	output, err := docker.Exec(config.Debug, args...)
 	if err != nil {
 		log.Println(output)
 		return err

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,7 +1,6 @@
 package manifest
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestRead(t *testing.T) {
 				"site_url":  "https://docs.traefik.io",
 				"copyright": "Copyright &copy; 2016-2019 Containous",
 				"extra": map[interface{}]interface{}{
-					"traefikVersion": "powpow",
+					"traefikVersion": TempPrefixEnvName + "TRAEFIK_VERSION",
 				},
 				"theme": map[interface{}]interface{}{
 					"include_sidebar": true,
@@ -113,8 +112,6 @@ func TestRead(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			err := os.Setenv("TRAEFIK_VERSION", "powpow")
-			require.NoError(t, err)
 			content, err := Read(filepath.Join(".", "fixtures", test.filename))
 			require.NoError(t, err)
 


### PR DESCRIPTION
### Description

This PR allow structor to use `.env` file during the documentation build.

This also remove the environment variable substitution from structor and let mkdocs to do it.

